### PR TITLE
Fix migrator state restore

### DIFF
--- a/pkg/model/migrator/validator.go
+++ b/pkg/model/migrator/validator.go
@@ -192,6 +192,9 @@ func (m *Validator) validateConfirmation(confirmation *api.WhiteFlagConfirmation
 	return includedBundles, nil
 }
 
+// nextMigrations queries the next existing migrations starting from milestone index startIndex.
+// It returns the migrations as well as milestone index that confirmed those migrations.
+// If there are currently no more migrations, it returns the latest milestone index that was checked.
 func (m *Validator) nextMigrations(startIndex uint32) (uint32, []*iota.MigratedFundsEntry, error) {
 	info, err := m.api.GetNodeInfo()
 	if err != nil {

--- a/plugins/migrator/plugin.go
+++ b/plugins/migrator/plugin.go
@@ -70,12 +70,12 @@ func provide(c *dig.Container) {
 func configure() {
 	log = logger.NewLogger(Plugin.Name)
 
-	var state *migrator.State
+	var msIndex *uint32
 	if *bootstrap {
-		state = &migrator.State{LatestMilestoneIndex: *startIndex}
+		msIndex = startIndex
 	}
 	// TODO: perform sanity check, that the latest migration milestone has MigratedAt lower than the state
-	if err := deps.MigratorService.InitState(state); err != nil {
+	if err := deps.MigratorService.InitState(msIndex); err != nil {
 		log.Fatalf("failed to initialize migrator: %s", err)
 	}
 }


### PR DESCRIPTION
Fix bug that lead to the `LastIncludedIndex` not being restored from state.